### PR TITLE
Promises to enable clean load test scripts as complexity increases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ With the MeteorDown script, you can call methods and invoke subscriptions. The f
 
 This ddp client is based on [node-ddp-client](https://github.com/oortcloud/node-ddp-client) but with some changes to make it more Meteor like. Let's look at APIs:
 
-###Meteor.call
+###Meteor.call and Meteor.apply
 
 ~~~js
 Meteor.call('name'[, args*], callback)
+~~~
+
+and
+
+~~~js
+Meteor.call('name'[, args], callback)
 ~~~
 
 Call a Meteor method. Just like the browser client, the callback will receive 2 arguments Error and the Result.
@@ -54,6 +60,15 @@ Meteor.subscribe('name'[, args*], callback)
 ~~~
 
 The callback function will be called when the subscription is ready and all initial data is loaded to the client.
+
+###Handling More Complex Pipelines with Promises
+
+For more complicated load-testing pipelines, a `Promise`-enabled versions of `Meteor.call`, `Meteor.apply` and `Meteor.subscribe` are available as:
+ - `Meteor.call_GetPromise('name'[, args*])`
+ - `Meteor.apply_GetPromise('name'[, args])`
+ - `Meteor.subscribe_GetPromise('name'[, args*])`
+
+Simply omit the callback parameter and work with the `Promise` that is returned.
 
 ###Meteor.kill
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,6 +40,57 @@ Client.prototype.call = function () {
   });
 }
 
+Client.prototype.apply = function() {
+  if ((arguments.length === 0) || (typeof arguments[0] !== "string")) {
+    throw new Error("invalid method call")
+  }
+  var methodName = arguments[0];
+  var applyArgs = [methodName];
+  var args, cb;
+  
+  if (arguments.length >= 2) {
+    args = arguments[1];
+    if (!_.isArray(args)) {
+      throw new Error("invalid apply arguments parameter");
+    }
+    applyArgs = applyArgs.concat(args);
+  }
+  if (arguments.length >= 3) {
+    cb = arguments[2];
+    if (!_.isFunction(cb)) {
+      throw new Error("invalid callback parameter");
+    }
+    applyArgs = applyArgs.concat(cb);
+  }
+  this.call.apply(this, applyArgs);
+};
+
+Client.prototype.call_GetPromise = function() {
+  var self = this;
+  var args = Array.prototype.slice.call(arguments);
+  return new Promise(function(resolve, reject) {
+    self.call.apply(self, args.concat(function(err, res) {
+      if (!!err) {
+        reject(err);
+      }
+      resolve(res);
+    }));
+  });
+};
+
+Client.prototype.apply_GetPromise = function() {
+  var self = this;
+  var args = Array.prototype.slice.call(arguments);
+  return new Promise(function(resolve, reject) {
+    self.apply.apply(self, args.concat(function(err, res) {
+      if (!!err) {
+        reject(err);
+      }
+      resolve(res);
+    }));
+  });
+};
+
 Client.prototype._subscribe = Client.prototype.subscribe;
 Client.prototype.subscribe = function () {
   var self = this;
@@ -59,6 +110,21 @@ Client.prototype.subscribe = function () {
     callback && callback.apply(null, arguments);
   });
 }
+
+Client.prototype.subscribe_GetPromise = function() {
+  var self = this;
+  var args = Array.prototype.slice.call(arguments);
+  return new Promise(function(resolve, reject) {
+    self.subscribe.apply(self, args.concat(function(err, res) {
+      if (!!err) {
+        reject(err);
+      }
+      resolve(res);
+    }));
+  });
+};
+
+
 
 Client.prototype.kill = function () {
   this.close();


### PR DESCRIPTION
The following changes were made:
- Added Meteor.apply (via `Client.prototype`)
- Added Meteor.call_GetPromise (via `Client.prototype`)
- Added Meteor.apply_GetPromise (via `Client.prototype`)
- Added Meteor.subscribe_GetPromise (via `Client.prototype`)

The Promise methods enable more complicated load tests. For instance, for the simple [todos](https://www.meteor.com/todos) example, a good load test would:
- start subscriptions to get all lists
  - one for public lists
  - another subscriptions for private lists
- for each list so obtained, subscribe to the list items

This implies a level of asyncrony that vanilla `Meteor.subscribe` with callbacks cannot provide for. The same applies for methods. What we need are simple promises. So here is the described load test for Meteor's `todos` example:

``` javascript
LoadTester.addTask('get-all-data', function(Meteor, complete) {
    Promise.resolve()
        .then(function() {
            // Subscribe to both public lists and private lists
            return Promise.all([
                new Promise(function(resolve, reject) {
                    Meteor.subscribe('publicLists', function() {
                        resolve();
                    });
                }),
                Meteor.subscribe_GetPromise('privateLists')
            ]);
        })
        .then(function() {
            // For each available list, subscribe to the contents of each list
            return Promise.all(
                Object.keys(Meteor.collections.lists).map(
                    id => Meteor.subscribe_GetPromise('todos', id)
                )
            );
        })
        .then(function() {
            // Report what was done and complete task
            console.log(Object.keys(Meteor.collections.todos).length + ' todos from ' + Object.keys(Meteor.collections.lists).length + ' lists downloaded.');
            complete();
        });
});
```

Don't mind the `LoadTest` object and the `complete` method. It's part of a ["quickstart"](https://github.com/convexset/meteor-down-quickstart) I've been goofing around with.
